### PR TITLE
Ensure "this" gets set properly inside app methods

### DIFF
--- a/www/js/index.js
+++ b/www/js/index.js
@@ -12,7 +12,9 @@ var appomat = {};
 appomat.app = {
 	
     initialize: function() {
-		document.addEventListener('deviceready', this.onDeviceReady, false);
+		document.addEventListener('deviceready', function(){
+			this.onDeviceReady();
+		}, false);
     },
 
     onDeviceReady: function() {


### PR DESCRIPTION
Currently the value of `this` inside `onDeviceReady` is not set to `appomat.app` as most people would expect. This tripped me up once I started adding methods and state to the `app` object.
