### PR TITLE
Ensure "this" is set correctly inside onDeviceReady

### DIFF
--- a/www/js/index.js
+++ b/www/js/index.js
@@ -12,7 +12,10 @@ var appomat = {};
 appomat.app = {
 	
     initialize: function() {
-		document.addEventListener('deviceready', this.onDeviceReady, false);
+        var self = this;
+        document.addEventListener('deviceready', function(){
+            self.onDeviceReady();
+        }, false);
     },
 
     onDeviceReady: function() {


### PR DESCRIPTION
Messed up the last pull request (#4), let's try this again:

Currently the value of `this` inside `onDeviceReady` is not set to `appomat.app` as most people would expect. This tripped me up once I started adding methods and state to the `app` object.